### PR TITLE
Date Format in eShop Admin fixed

### DIFF
--- a/oxid_4.7/copy_this/modules/norecalc/controllers/admin/norecalc_order_main.php
+++ b/oxid_4.7/copy_this/modules/norecalc/controllers/admin/norecalc_order_main.php
@@ -24,7 +24,7 @@ class norecalc_order_main extends norecalc_order_main_parent
     {
         $aParams = oxRegistry::getConfig()->getRequestParameter( "editval" );
         //No Invoice generated yet, recalculate order and save
-        if (!$this->hasInvoice() && !$aParams['oxorder__oxbillnr'] && ( !$aParams['oxorder__oxpaid'] || $aParams['oxorder__oxpaid'] == "0000-00-00 00:00:00" )){
+        if (!$this->hasInvoice() && !$aParams['oxorder__oxbillnr'] && ( !$aParams['oxorder__oxpaid'] || strpos($aParams['oxorder__oxpaid'], '0000') !== false)){ 
             return parent::save();
         }
         


### PR DESCRIPTION
Module now works even if the date format in eShop admin is set to EUR or
US.
